### PR TITLE
Use orderly1 for old orderly

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,12 +1,13 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -18,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -29,20 +30,22 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          error-on: '"error"'
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: moz.utils
 Type: Package
 Title: Utility functions
-Version: 0.1.89
+Version: 0.1.90
 Authors@R: 
     person(given = "Oli",
            family = "Stevens",
@@ -19,12 +19,12 @@ Imports:
   ggplot2,
   gtools,
   magrittr,
-  orderly,
+  orderly1,
   orderlyweb,
   plyr,
   purrr,
   rprojroot,
   sf
 Remotes:
-  vimc/orderly,
+  vimc/orderly1,
   vimc/orderlyweb

--- a/R/orderly_functions.R
+++ b/R/orderly_functions.R
@@ -13,10 +13,10 @@ orderly_dev_start_oli <- function(task, iso3 = NULL, version = 2022, pull_depend
     param <- NULL
 
   if(pull_dependencies)
-    orderly::orderly_pull_dependencies(task, remote = remote, parameters = param, recursive=TRUE)
+    orderly1::orderly_pull_dependencies(task, remote = remote, parameters = param, recursive=TRUE)
 
   setwd(rprojroot::find_rstudio_root_file())
-  orderly::orderly_develop_start(task, param, envir = envir)
+  orderly1::orderly_develop_start(task, param, envir = envir)
   setwd(paste0("src/", task))
 }
 
@@ -24,7 +24,7 @@ orderly_clean_all <- function() {
 
   setwd(rprojroot::find_rstudio_root_file())
   tasks <- grep("README", list.files("src"),  invert = TRUE, value = TRUE)
-  lapply(tasks, orderly::orderly_develop_clean)
+  lapply(tasks, orderly1::orderly_develop_clean)
   orderly_cleanup()
 
 }
@@ -32,10 +32,10 @@ orderly_clean_all <- function() {
 orderly_pull_oli <- function(task, iso3 = NULL, remote = "inference-web", recursive = TRUE) {
 
   # .onLoad <- function(lib, pkg) {
-  #   possibly_pull <<- purrr::possibly(.f = orderly::orderly_pull_archive, quiet = FALSE)
+  #   possibly_pull <<- purrr::possibly(.f = orderly1::orderly_pull_archive, quiet = FALSE)
   # }
 
-  possibly_pull <- purrr::possibly(.f = orderly::orderly_pull_archive, otherwise = NULL, quiet = FALSE)
+  possibly_pull <- purrr::possibly(.f = orderly1::orderly_pull_archive, otherwise = NULL, quiet = FALSE)
 
   if(!is.null(iso3)) {
     res <- purrr::map(iso3, ~possibly_pull(task, id = paste0('latest(parameter:iso3 == "', .x, '" && parameter:version == 2022)'), recursive = recursive, remote = remote))
@@ -47,7 +47,7 @@ orderly_pull_oli <- function(task, iso3 = NULL, remote = "inference-web", recurs
     # if(length(fail_iso3))
     #   message(paste0(names(fail_iso3), collapse = ", "), " failed")
   } else {
-    orderly::orderly_pull_archive(task, recursive = recursive, remote = remote)
+    orderly1::orderly_pull_archive(task, recursive = recursive, remote = remote)
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # moz.utils
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/mrc-ide/moz.utils/workflows/R-CMD-check/badge.svg)](https://github.com/mrc-ide/moz.utils/actions)
+[![R-CMD-check](https://github.com/mrc-ide/moz.utils/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/mrc-ide/moz.utils/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->


### PR DESCRIPTION
This PR updates the package to use `orderly1` to refer to old orderly, which is required now that we have renamed the package in advance of the release of orderly2.  The `orderly1` package is a snapshot of the last version of the old yaml-based orderly and will be available for the forseeable.

I've updated the gha files, but the build still fails - however, the failures are all pre-existing and things for you to sort at your leisure :)

This fix is required to redeploy the kp-data shiny app
